### PR TITLE
WP7 gap closure: agreement-driven cross-checks and the missing write UIs

### DIFF
--- a/backend/app/routers/feedback.py
+++ b/backend/app/routers/feedback.py
@@ -16,6 +16,7 @@ from backend.app.services.feedback import (
     upsert_feedback,
 )
 from backend.app.services.read.pagination import Page, page_params
+from backend.app.tasks.ingest import _send_cross_checks
 
 router = APIRouter(prefix="/api/v1", tags=["feedback"])
 ROLES = ("hr", "hr_lead", "admin")
@@ -49,14 +50,18 @@ async def upsert(
 ) -> FeedbackItem:
     score = await _load_score(db, candidate_id, score_id)
     try:
-        fb = await upsert_feedback(
+        fb, queued = await upsert_feedback(
             db, score=score, reviewer_id=user.id, decision=payload.decision, reason=payload.reason
         )
     except FeedbackReasonRequired as exc:
+        await db.rollback()
         raise HTTPException(
             status_code=422,
             detail={"code": "feedback_reason_required", "message": "与 AI 不一致时必须填写理由"},
         ) from exc
+    # Commit the feedback and its queued cross-check together, then deliver.
+    await db.commit()
+    _send_cross_checks(queued)
     return _serialize(fb, user.display_name)
 
 

--- a/backend/app/routers/golden_set.py
+++ b/backend/app/routers/golden_set.py
@@ -25,6 +25,7 @@ from backend.app.services.golden_set import (
     parse_golden_csv,
 )
 from backend.app.services.read.pagination import Page, page_params
+from backend.app.tasks.ingest import _send_cross_checks
 
 router = APIRouter(prefix="/api/v1", tags=["golden-set"])
 IMPORT_ROLES = ("hr_lead", "admin")
@@ -60,7 +61,11 @@ async def import_golden(
                 "message": f"单次导入不超过 {settings.GOLDEN_IMPORT_MAX_ROWS} 行",
             },
         ) from exc
-    created, updated, db_errors = await import_golden_set(db, parsed=parsed, importer_id=user.id)
+    created, updated, db_errors, queued = await import_golden_set(
+        db, parsed=parsed, importer_id=user.id
+    )
+    await db.commit()
+    _send_cross_checks(queued)
     all_errors = sorted([*fmt_errors, *db_errors], key=lambda e: e.row)
     return GoldenImportResult(
         total=len(parsed) + len(fmt_errors),

--- a/backend/app/services/cross_check/triggers.py
+++ b/backend/app/services/cross_check/triggers.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.config import get_settings
+from backend.app.models import Feedback, GoldenSet, RuleVersion, Score
+from backend.app.rules.schema import RuleSchema
+from backend.app.services.cross_check.sampling import (
+    CrossCheckContext,
+    eligible,
+    trigger_reasons,
+)
+from backend.app.services.cross_check.state import ensure_cross_check
+
+JUDGE_PROMPT_VERSION_FALLBACK = "resume_judge_v1"
+
+
+def _persisted_dimensions(score: Score) -> list[dict[str, Any]]:
+    entries = (score.judge_dimensions or {}).get("dimensions")
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+async def queue_cross_check_for_score(
+    db: AsyncSession,
+    *,
+    score: Score,
+    admin_backfill: bool = False,
+    prompt_version: str | None = None,
+) -> list[int]:
+    """Queue a second opinion for one score if any trigger fires.
+
+    The caller owns the commit, so the queue row lands in the same transaction
+    as whatever caused it — a rolled-back feedback or score can never leave an
+    orphaned check behind. Returns the queued row ids for post-commit delivery.
+    """
+    settings = get_settings()
+    version = await db.get(RuleVersion, score.rule_version_id)
+    if version is None:
+        return []
+    try:
+        schema = RuleSchema.model_validate(version.schema_json)
+    except Exception:
+        # An invalid bound schema cannot be re-judged meaningfully.
+        return []
+
+    golden_label = (
+        await db.execute(
+            select(GoldenSet.label).where(
+                GoldenSet.candidate_id == score.candidate_id,
+                GoldenSet.jd_id == score.jd_id,
+            )
+        )
+    ).scalar_one_or_none()
+    # Any reviewer disagreement on this score is enough to warrant a second look.
+    disagreed = (
+        await db.execute(
+            select(Feedback.id).where(
+                Feedback.score_id == score.id, Feedback.ai_agreed.is_(False)
+            )
+        )
+    ).first()
+
+    context = CrossCheckContext(
+        score_id=score.id,
+        jd_id=score.jd_id,
+        prompt_version=prompt_version or JUDGE_PROMPT_VERSION_FALLBACK,
+        secondary_model=settings.CROSS_ENGINE_MODEL,
+        primary_model=settings.LLM_MODEL_JUDGE,
+        schema_dimension_ids=[dim.id for dim in schema.judge_dimensions],
+        judge_dimensions=_persisted_dimensions(score),
+        grade=score.grade,
+        sample_percent=settings.CROSS_ENGINE_SAMPLE_PERCENT,
+        low_confidence=Decimal(str(settings.CROSS_ENGINE_LOW_CONFIDENCE)),
+        golden_label=golden_label,
+        ai_agreed=False if disagreed is not None else None,
+        weights={
+            (score.jd_id, dim.id): Decimal(str(dim.weight))
+            for dim in schema.judge_dimensions
+        },
+    )
+    if not eligible(context):
+        return []
+    reasons = trigger_reasons(context, admin_backfill=admin_backfill)
+    if not reasons:
+        return []
+
+    row = await ensure_cross_check(
+        db,
+        score_id=score.id,
+        secondary_model=settings.CROSS_ENGINE_MODEL,
+        prompt_version=context.prompt_version,
+        reasons=reasons,
+        threshold=Decimal(str(settings.CROSS_ENGINE_DIFF_THRESHOLD)),
+    )
+    return [row.id]

--- a/backend/app/services/feedback.py
+++ b/backend/app/services/feedback.py
@@ -31,7 +31,12 @@ def derive_ai_agreed(grade: str, decision: str) -> bool | None:
 
 async def upsert_feedback(
     db: AsyncSession, *, score: Score, reviewer_id: int, decision: str, reason: str | None
-) -> Feedback:
+) -> tuple[Feedback, list[int]]:
+    """Record one reviewer's verdict and queue a cross-check on disagreement.
+
+    The caller owns the commit so the feedback row and the queued check land
+    together; returns the queued row ids for post-commit Celery delivery.
+    """
     ai_agreed = derive_ai_agreed(score.grade, decision)
     normalized_reason = (reason or "").strip() or None
     if ai_agreed is False and not normalized_reason:
@@ -57,10 +62,15 @@ async def upsert_feedback(
         .returning(Feedback.id)
     )
     feedback_id = (await db.execute(stmt)).scalar_one()
-    await db.commit()
-    return (
+    await db.flush()
+
+    from backend.app.services.cross_check.triggers import queue_cross_check_for_score
+
+    queued = await queue_cross_check_for_score(db, score=score)
+    feedback = (
         await db.execute(select(Feedback).where(Feedback.id == feedback_id))
     ).scalar_one()
+    return feedback, queued
 
 
 async def list_feedback(db: AsyncSession, score_id: int) -> list[tuple[Feedback, str]]:

--- a/backend/app/services/golden_set.py
+++ b/backend/app/services/golden_set.py
@@ -72,9 +72,14 @@ def parse_golden_csv(content: bytes, *, max_rows: int) -> tuple[list[ParsedRow],
 
 async def import_golden_set(
     db: AsyncSession, *, parsed: list[ParsedRow], importer_id: int
-) -> tuple[int, int, list[RowError]]:
+) -> tuple[int, int, list[RowError], list[int]]:
+    """Upsert authoritative labels and queue cross-checks for AI/label conflicts.
+
+    The caller owns the commit so labels and queued checks land together;
+    returns the queued row ids for post-commit Celery delivery.
+    """
     if not parsed:
-        return 0, 0, []
+        return 0, 0, [], []
     jd_codes = {r.jd_code for r in parsed}
     jd_rows = (await db.execute(select(JD.code, JD.id).where(JD.code.in_(jd_codes)))).all()
     jd_map: dict[str, int] = {code: jd_id for code, jd_id in jd_rows}
@@ -133,8 +138,26 @@ async def import_golden_set(
                 },
             )
         )
-    await db.commit()
-    return created, updated, errors
+    await db.flush()
+
+    from backend.app.services.cross_check.triggers import queue_cross_check_for_score
+
+    # A newly authoritative label can contradict a score the AI already made;
+    # `golden_error` is exactly that case.
+    queued: list[int] = []
+    touched = [(jd_map[r.jd_code], r.candidate_id) for r in parsed if r.jd_code in jd_map]
+    if touched:
+        scores = (
+            await db.execute(
+                select(Score).where(
+                    tuple_(Score.jd_id, Score.candidate_id).in_(touched),
+                    Score.judge_dimensions.isnot(None),
+                )
+            )
+        ).scalars()
+        for score in scores:
+            queued.extend(await queue_cross_check_for_score(db, score=score))
+    return created, updated, errors, queued
 
 
 async def list_golden_set(

--- a/backend/tests/integration/test_cross_check_triggers.py
+++ b/backend/tests/integration/test_cross_check_triggers.py
@@ -160,3 +160,76 @@ async def test_rescoring_the_same_configuration_is_idempotent(db_session) -> Non
         await db_session.execute(select(func.count()).select_from(ScoreCrossCheck))
     ).scalar_one()
     assert total == 1
+
+
+async def test_hr_disagreement_queues_a_check_in_the_feedback_transaction(
+    db_session,
+) -> None:
+    from backend.app.models import User
+    from backend.app.services.feedback import upsert_feedback
+
+    jd, candidate = await _seed(db_session)
+    result = await ScoringPipeline(db=db_session, judge=_judge(0.99)).run(
+        candidate_id=candidate.id, jd_id=jd.id
+    )
+    score = await db_session.get(Score, result.score_id)
+    assert score is not None
+    reviewer = User(
+        dingtalk_userid=f"rev-{uuid4().hex}", display_name="Reviewer", role="hr"
+    )
+    db_session.add(reviewer)
+    await db_session.flush()
+
+    # The AI advanced this candidate; the reviewer rejects it.
+    _feedback, queued = await upsert_feedback(
+        db_session,
+        score=score,
+        reviewer_id=reviewer.id,
+        decision="reject",
+        reason="经验不符",
+    )
+    await db_session.commit()
+
+    assert queued
+    row = (
+        await db_session.execute(
+            select(ScoreCrossCheck).where(ScoreCrossCheck.score_id == score.id)
+        )
+    ).scalar_one()
+    assert "ai_hr_disagreement" in row.sample_reasons
+
+
+async def test_feedback_rollback_removes_both_business_and_queue_writes(
+    db_session,
+) -> None:
+    from backend.app.models import Feedback, User
+    from backend.app.services.feedback import upsert_feedback
+
+    jd, candidate = await _seed(db_session)
+    result = await ScoringPipeline(db=db_session, judge=_judge(0.99)).run(
+        candidate_id=candidate.id, jd_id=jd.id
+    )
+    score = await db_session.get(Score, result.score_id)
+    assert score is not None
+    reviewer = User(
+        dingtalk_userid=f"rev-{uuid4().hex}", display_name="Reviewer", role="hr"
+    )
+    db_session.add(reviewer)
+    await db_session.flush()
+
+    await upsert_feedback(
+        db_session,
+        score=score,
+        reviewer_id=reviewer.id,
+        decision="reject",
+        reason="经验不符",
+    )
+    # The service no longer commits, so the caller can still take it all back.
+    await db_session.rollback()
+
+    assert (
+        await db_session.execute(select(func.count()).select_from(Feedback))
+    ).scalar_one() == 0
+    assert (
+        await db_session.execute(select(func.count()).select_from(ScoreCrossCheck))
+    ).scalar_one() == 0

--- a/frontend/e2e/wp7-quality.spec.ts
+++ b/frontend/e2e/wp7-quality.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect } from "@playwright/test";
+import { mintSession } from "./helpers/session";
+
+// Covers the WP7 quality-release workspace: the read-only list, the gated
+// preview -> create flow, and the leak blacklist. Same stubbing approach as the
+// other specs — a real signed cookie plus page.route on the BFF proxy.
+
+const RELEASE_LIST = {
+  items: [
+    {
+      id: 7,
+      status: "below_target",
+      window_start: "2026-06-26T05:00:00Z",
+      window_end: "2026-07-26T05:00:00Z",
+      created_at: "2026-07-26T05:00:00Z",
+      created_by: { user_id: 3, display_name: "质量负责人" },
+      golden_snapshot_sha256: "a".repeat(64),
+    },
+  ],
+  page: 1,
+  page_size: 20,
+  total: 1,
+};
+
+const PREVIEW = {
+  window_start: "2026-06-26T05:00:00Z",
+  window_end: "2026-07-26T05:00:00Z",
+  selected: [{ jd_id: 1, jd_code: "FOREIGN_TRADE", rule_version_id: 4 }],
+  golden_total: 12,
+  golden_advance: 7,
+  golden_reject: 4,
+  golden_borderline: 1,
+  score_covered: 10,
+  score_uncovered: 2,
+  targets: { f1_target: 0.75 },
+  input_fingerprint: "b".repeat(64),
+};
+
+async function signIn(context: import("@playwright/test").BrowserContext, role: string) {
+  await context.addCookies([
+    {
+      name: "ssa_session",
+      value: mintSession({ token: "e2e", displayName: "测试Lead", role }),
+      url: "http://127.0.0.1:4173",
+    },
+  ]);
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/proxy/api/v1/quality/releases?**", (r) =>
+    r.fulfill({ status: 200, json: RELEASE_LIST }),
+  );
+  await page.route("**/api/proxy/api/v1/quality/releases", (r) =>
+    r.request().method() === "POST"
+      ? r.fulfill({
+          status: 201,
+          json: {
+            ...PREVIEW,
+            id: 8,
+            status: "meets_target",
+            golden_snapshot_sha256: "c".repeat(64),
+            golden_snapshot_item_count: 12,
+            created_at: "2026-07-26T06:00:00Z",
+            created_by: { user_id: 3, display_name: "质量负责人" },
+            classification: {
+              labeled_total: 12,
+              covered: 10,
+              uncovered: 2,
+              borderline_excluded: 1,
+              confusion: { tp: 6, fp: 1, tn: 3, fn: 0 },
+              precision: 0.857,
+              recall: 1,
+              f1: 0.923,
+              accuracy: 0.9,
+            },
+            evidence: {
+              participating_candidates: 10,
+              hard_filter_rejects: 0,
+              expected_count: 10,
+              covered_count: 10,
+              value: 1,
+              status: "ok",
+            },
+            confidence: {
+              available_count: 10,
+              confidence_unavailable: 0,
+              bins: [],
+              ece: null,
+            },
+            agreement: {
+              agreed: 8,
+              disagreed: 1,
+              hold: 1,
+              denominator: 9,
+              agreement_rate: 0.888,
+            },
+            f1_target_result: { value: 0.923, target: 0.75, status: "meets_target" },
+            evidence_target_result: { value: 1, target: 0.95, status: "meets_target" },
+            operations: {
+              current: {
+                attempt_count: 0,
+                succeeded_count: 0,
+                failed_count: 0,
+                abandoned_count: 0,
+                unknown_usage_count: 0,
+                known_cost_cny: 0,
+                p50_latency_ms: null,
+                p95_latency_ms: null,
+                scored_count: 0,
+                scores_per_day: null,
+              },
+              previous: {
+                attempt_count: 0,
+                succeeded_count: 0,
+                failed_count: 0,
+                abandoned_count: 0,
+                unknown_usage_count: 0,
+                known_cost_cny: 0,
+                p50_latency_ms: null,
+                p95_latency_ms: null,
+                scored_count: 0,
+                scores_per_day: null,
+              },
+              cost_delta: { absolute: 0, percentage: null },
+              attempt_delta: { absolute: 0, percentage: null },
+            },
+            by_jd: [],
+          },
+        })
+      : r.fulfill({ status: 200, json: RELEASE_LIST }),
+  );
+  await page.route("**/api/proxy/api/v1/quality/releases/preview", (r) =>
+    r.fulfill({ status: 200, json: PREVIEW }),
+  );
+});
+
+test("the release list shows status and snapshot without candidate content", async ({
+  context,
+  page,
+}) => {
+  await signIn(context, "hr");
+  await page.goto("/reports/quality");
+
+  await expect(page.getByRole("heading", { name: "质量发布" })).toBeVisible();
+  await expect(page.getByText("未达标")).toBeVisible();
+  await expect(page.getByText("质量负责人")).toBeVisible();
+
+  const body = (await page.locator("body").innerHTML()).toLowerCase();
+  for (const forbidden of ["candidate_id", "name_cipher", "evidence_quotes", "bearer "]) {
+    expect(body).not.toContain(forbidden);
+  }
+});
+
+test("a plain reviewer cannot reach the create control", async ({ context, page }) => {
+  await signIn(context, "hr");
+  await page.goto("/reports/quality");
+  await expect(page.getByRole("heading", { name: "质量发布" })).toBeVisible();
+
+  await expect(page.getByRole("button", { name: "创建发布" })).toHaveCount(0);
+});
+
+test("a lead previews the frozen inputs and then creates the release", async ({
+  context,
+  page,
+}) => {
+  await signIn(context, "hr_lead");
+  await page.goto("/reports/quality");
+
+  await page.getByRole("button", { name: "创建发布" }).click();
+
+  // The preview must state exactly what is about to be frozen.
+  await expect(page.getByText("共 12 条（推进 7／淘汰 4／borderline 1）")).toBeVisible();
+  await expect(page.getByText("已覆盖 10，未覆盖 2")).toBeVisible();
+  await expect(page.getByText("FOREIGN_TRADE@4")).toBeVisible();
+
+  await page.getByRole("button", { name: "确认创建" }).click();
+
+  await expect(page.getByText("已创建发布 #8")).toBeVisible();
+});

--- a/frontend/src/app/(app)/reports/cross-checks/page.tsx
+++ b/frontend/src/app/(app)/reports/cross-checks/page.tsx
@@ -1,98 +1,12 @@
-"use client";
+import { cookies } from "next/headers";
+import { readSession, SESSION_COOKIE } from "@/lib/server/session";
+import { CrossCheckView } from "@/components/cross-check-view";
 
-import { useQuery } from "@tanstack/react-query";
+export const dynamic = "force-dynamic";
 
-import { useShellHeader } from "@/components/app-session-context";
-import { DataState } from "@/components/data-state";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { apiGet } from "@/lib/api-client";
-import { SuspiciousPage } from "@/lib/wp7-schemas";
-
-const REASON_LABEL: Record<string, string> = {
-  deterministic_sample: "抽样",
-  low_confidence: "低置信度",
-  golden_error: "与金标不符",
-  ai_hr_disagreement: "与 HR 不一致",
-  admin_backfill: "管理员回填",
-};
-
-export default function CrossChecksPage() {
-  const query = useQuery({
-    queryKey: ["cross-checks-suspicious"],
-    queryFn: () =>
-      apiGet("/api/v1/cross-checks/suspicious", {}, SuspiciousPage),
-  });
-
-  useShellHeader({
-    breadcrumbs: [{ label: "报表" }, { label: "交叉校验" }],
-    lastRefreshedAt: query.dataUpdatedAt
-      ? new Date(query.dataUpdatedAt).toLocaleTimeString("zh-CN")
-      : null,
-  });
-
-  return (
-    <section className="space-y-6">
-      <h1 className="text-xl font-semibold">交叉校验存疑列表</h1>
-      <p className="text-sm text-muted-foreground">
-        次引擎重新评分与主评分差异超过阈值的候选人。次引擎结果仅作参考，不会替换主评分。
-      </p>
-
-      <DataState
-        isLoading={query.isLoading}
-        error={query.error ? { message: (query.error as Error).message } : null}
-        isEmpty={query.data?.items.length === 0}
-        emptyText="没有超过阈值的差异"
-        onRetry={() => query.refetch()}
-      >
-        {query.data && (
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>候选人</TableHead>
-                  <TableHead>JD</TableHead>
-                  <TableHead>主评分</TableHead>
-                  <TableHead>次引擎</TableHead>
-                  <TableHead>差异</TableHead>
-                  <TableHead>触发原因</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {query.data.items.map((item) => (
-                  <TableRow key={item.cross_check_id}>
-                    <TableCell>#{item.candidate_id}</TableCell>
-                    <TableCell>{item.jd_code}</TableCell>
-                    <TableCell className="tabular-nums">
-                      {item.primary_total_score ?? "—"}
-                    </TableCell>
-                    <TableCell className="tabular-nums">
-                      {item.secondary_total_score ?? "—"}
-                    </TableCell>
-                    <TableCell className="tabular-nums font-medium">
-                      {item.absolute_diff ?? "—"}
-                      <span className="text-xs text-muted-foreground">
-                        （阈值 {item.threshold ?? "—"}）
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-xs">
-                      {item.sample_reasons
-                        .map((reason) => REASON_LABEL[reason] ?? reason)
-                        .join("、")}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )}
-      </DataState>
-    </section>
-  );
+export default async function CrossChecksPage() {
+  const session = await readSession((await cookies()).get(SESSION_COOKIE)?.value);
+  // Backfill spends real money on provider calls, so it stays admin-only.
+  const canBackfill = session?.role === "admin";
+  return <CrossCheckView canBackfill={canBackfill} />;
 }

--- a/frontend/src/app/(app)/reports/quality/page.tsx
+++ b/frontend/src/app/(app)/reports/quality/page.tsx
@@ -1,94 +1,12 @@
-"use client";
+import { cookies } from "next/headers";
+import { readSession, SESSION_COOKIE } from "@/lib/server/session";
+import { QualityReleasesView } from "@/components/quality/quality-release-view";
 
-import { useQuery } from "@tanstack/react-query";
+export const dynamic = "force-dynamic";
 
-import { useShellHeader } from "@/components/app-session-context";
-import { DataState } from "@/components/data-state";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { apiGet } from "@/lib/api-client";
-import { QualityReleaseList } from "@/lib/wp7-schemas";
-
-const STATUS_LABEL: Record<string, string> = {
-  meets_target: "达标",
-  below_target: "未达标",
-};
-
-export default function QualityReleasesPage() {
-  const query = useQuery({
-    queryKey: ["quality-releases"],
-    queryFn: () => apiGet("/api/v1/quality/releases", {}, QualityReleaseList),
-  });
-
-  useShellHeader({
-    breadcrumbs: [{ label: "报表" }, { label: "质量发布" }],
-    lastRefreshedAt: query.dataUpdatedAt
-      ? new Date(query.dataUpdatedAt).toLocaleTimeString("zh-CN")
-      : null,
-  });
-
-  return (
-    <section className="space-y-6">
-      <h1 className="text-xl font-semibold">质量发布</h1>
-      <p className="text-sm text-muted-foreground">
-        每个发布把一份内容寻址的黄金集快照与各 JD 当时的 active
-        规则版本绑定，创建后不可变。
-      </p>
-
-      <DataState
-        isLoading={query.isLoading}
-        error={query.error ? { message: (query.error as Error).message } : null}
-        isEmpty={query.data?.items.length === 0}
-        emptyText="还没有质量发布"
-        onRetry={() => query.refetch()}
-      >
-        {query.data && (
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>发布</TableHead>
-                  <TableHead>状态</TableHead>
-                  <TableHead>观察窗口</TableHead>
-                  <TableHead>快照</TableHead>
-                  <TableHead>创建人</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {query.data.items.map((item) => (
-                  <TableRow key={item.id}>
-                    <TableCell>#{item.id}</TableCell>
-                    <TableCell>
-                      <span
-                        className={
-                          item.status === "meets_target"
-                            ? "text-emerald-700"
-                            : "text-red-700"
-                        }
-                      >
-                        {STATUS_LABEL[item.status]}
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-xs">
-                      {item.window_start} → {item.window_end}
-                    </TableCell>
-                    <TableCell className="font-mono text-xs">
-                      {item.golden_snapshot_sha256.slice(0, 12)}…
-                    </TableCell>
-                    <TableCell>{item.created_by.display_name}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )}
-      </DataState>
-    </section>
-  );
+export default async function QualityReleasesPage() {
+  const session = await readSession((await cookies()).get(SESSION_COOKIE)?.value);
+  // Creating a release freezes a permanent record, so it is a lead/admin action.
+  const canCreate = session?.role === "hr_lead" || session?.role === "admin";
+  return <QualityReleasesView canCreate={canCreate} />;
 }

--- a/frontend/src/components/cross-check-backfill.tsx
+++ b/frontend/src/components/cross-check-backfill.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import * as React from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ApiError, apiPost } from "@/lib/api-client";
+import { BackfillResult } from "@/lib/wp7-schemas";
+
+const ERROR_MESSAGE: Record<string, string> = {
+  invalid_cross_check_window: "时间窗口不合法",
+  cross_check_window_too_large: "时间窗口不能超过 90 天",
+  invalid_cross_check_limit: "数量超出允许范围",
+};
+
+export function CrossCheckBackfill({ canBackfill }: { canBackfill: boolean }) {
+  const [limit, setLimit] = React.useState("50");
+  const [preview, setPreview] = React.useState<BackfillResult | null>(null);
+  const queryClient = useQueryClient();
+
+  const run = useMutation({
+    mutationFn: (dryRun: boolean) =>
+      apiPost(
+        `/api/v1/cross-checks/backfill?limit=${encodeURIComponent(limit)}&dry_run=${dryRun}`,
+        {},
+        BackfillResult,
+      ),
+    onSuccess: (result) => {
+      setPreview(result);
+      if (!result.dry_run) {
+        toast.success(`已排队 ${result.newly_queued} 条`);
+        void queryClient.invalidateQueries({ queryKey: ["cross-checks-suspicious"] });
+      }
+    },
+    onError: (error) =>
+      toast.error(
+        error instanceof ApiError
+          ? (ERROR_MESSAGE[error.code] ?? error.message)
+          : (error as Error).message,
+      ),
+  });
+
+  if (!canBackfill) return null;
+
+  return (
+    <section className="space-y-3 rounded-md border p-4">
+      <h2 className="font-medium">回填交叉校验</h2>
+      <p className="text-sm text-muted-foreground">
+        对既有评分补跑次引擎校验。先试运行确认范围，再确认执行；已排队过的评分不会重复排队。
+      </p>
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="w-32 space-y-1">
+          <Label htmlFor="backfill-limit">数量上限</Label>
+          <Input
+            id="backfill-limit"
+            value={limit}
+            onChange={(event) => setLimit(event.target.value)}
+            inputMode="numeric"
+          />
+        </div>
+        <Button
+          variant="outline"
+          onClick={() => run.mutate(true)}
+          disabled={run.isPending}
+        >
+          试运行
+        </Button>
+        <Button
+          onClick={() => run.mutate(false)}
+          disabled={run.isPending || preview === null}
+        >
+          确认回填
+        </Button>
+      </div>
+
+      {preview && (
+        <p className="text-sm" data-testid="backfill-summary">
+          命中 {preview.selected} 条，已存在 {preview.already_existing} 条，
+          {preview.dry_run
+            ? `将排队 ${preview.would_queue} 条`
+            : `已排队 ${preview.newly_queued} 条`}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/cross-check-view.tsx
+++ b/frontend/src/components/cross-check-view.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { useShellHeader } from "@/components/app-session-context";
+import { DataState } from "@/components/data-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CrossCheckBackfill } from "@/components/cross-check-backfill";
+import { apiGet } from "@/lib/api-client";
+import { SuspiciousPage } from "@/lib/wp7-schemas";
+
+const REASON_LABEL: Record<string, string> = {
+  deterministic_sample: "抽样",
+  low_confidence: "低置信度",
+  golden_error: "与金标不符",
+  ai_hr_disagreement: "与 HR 不一致",
+  admin_backfill: "管理员回填",
+};
+
+export function CrossCheckView({ canBackfill }: { canBackfill: boolean }) {
+  const query = useQuery({
+    queryKey: ["cross-checks-suspicious"],
+    queryFn: () =>
+      apiGet("/api/v1/cross-checks/suspicious", {}, SuspiciousPage),
+  });
+
+  useShellHeader({
+    breadcrumbs: [{ label: "报表" }, { label: "交叉校验" }],
+    lastRefreshedAt: query.dataUpdatedAt
+      ? new Date(query.dataUpdatedAt).toLocaleTimeString("zh-CN")
+      : null,
+  });
+
+  return (
+    <section className="space-y-6">
+      <h1 className="text-xl font-semibold">交叉校验存疑列表</h1>
+      <p className="text-sm text-muted-foreground">
+        次引擎重新评分与主评分差异超过阈值的候选人。次引擎结果仅作参考，不会替换主评分。
+      </p>
+
+      <DataState
+        isLoading={query.isLoading}
+        error={query.error ? { message: (query.error as Error).message } : null}
+        isEmpty={query.data?.items.length === 0}
+        emptyText="没有超过阈值的差异"
+        onRetry={() => query.refetch()}
+      >
+        {query.data && (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>候选人</TableHead>
+                  <TableHead>JD</TableHead>
+                  <TableHead>主评分</TableHead>
+                  <TableHead>次引擎</TableHead>
+                  <TableHead>差异</TableHead>
+                  <TableHead>触发原因</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {query.data.items.map((item) => (
+                  <TableRow key={item.cross_check_id}>
+                    <TableCell>#{item.candidate_id}</TableCell>
+                    <TableCell>{item.jd_code}</TableCell>
+                    <TableCell className="tabular-nums">
+                      {item.primary_total_score ?? "—"}
+                    </TableCell>
+                    <TableCell className="tabular-nums">
+                      {item.secondary_total_score ?? "—"}
+                    </TableCell>
+                    <TableCell className="tabular-nums font-medium">
+                      {item.absolute_diff ?? "—"}
+                      <span className="text-xs text-muted-foreground">
+                        （阈值 {item.threshold ?? "—"}）
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {item.sample_reasons
+                        .map((reason) => REASON_LABEL[reason] ?? reason)
+                        .join("、")}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </DataState>
+
+      <CrossCheckBackfill canBackfill={canBackfill} />
+    </section>
+  );
+}

--- a/frontend/src/components/quality/quality-release-view.tsx
+++ b/frontend/src/components/quality/quality-release-view.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { useShellHeader } from "@/components/app-session-context";
+import { DataState } from "@/components/data-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ReleaseCreate } from "@/components/quality/release-create";
+import { apiGet } from "@/lib/api-client";
+import { QualityReleaseList } from "@/lib/wp7-schemas";
+
+const STATUS_LABEL: Record<string, string> = {
+  meets_target: "达标",
+  below_target: "未达标",
+};
+
+export function QualityReleasesView({ canCreate }: { canCreate: boolean }) {
+  const query = useQuery({
+    queryKey: ["quality-releases"],
+    queryFn: () => apiGet("/api/v1/quality/releases", {}, QualityReleaseList),
+  });
+
+  useShellHeader({
+    breadcrumbs: [{ label: "报表" }, { label: "质量发布" }],
+    lastRefreshedAt: query.dataUpdatedAt
+      ? new Date(query.dataUpdatedAt).toLocaleTimeString("zh-CN")
+      : null,
+  });
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">质量发布</h1>
+        <ReleaseCreate canCreate={canCreate} />
+      </div>
+      <p className="text-sm text-muted-foreground">
+        每个发布把一份内容寻址的黄金集快照与各 JD 当时的 active
+        规则版本绑定，创建后不可变。
+      </p>
+
+      <DataState
+        isLoading={query.isLoading}
+        error={query.error ? { message: (query.error as Error).message } : null}
+        isEmpty={query.data?.items.length === 0}
+        emptyText="还没有质量发布"
+        onRetry={() => query.refetch()}
+      >
+        {query.data && (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>发布</TableHead>
+                  <TableHead>状态</TableHead>
+                  <TableHead>观察窗口</TableHead>
+                  <TableHead>快照</TableHead>
+                  <TableHead>创建人</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {query.data.items.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell>#{item.id}</TableCell>
+                    <TableCell>
+                      <span
+                        className={
+                          item.status === "meets_target"
+                            ? "text-emerald-700"
+                            : "text-red-700"
+                        }
+                      >
+                        {STATUS_LABEL[item.status]}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {item.window_start} → {item.window_end}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {item.golden_snapshot_sha256.slice(0, 12)}…
+                    </TableCell>
+                    <TableCell>{item.created_by.display_name}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </DataState>
+    </section>
+  );
+}

--- a/frontend/src/components/quality/release-create.tsx
+++ b/frontend/src/components/quality/release-create.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import * as React from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { ApiError, apiPost } from "@/lib/api-client";
+import {
+  QualityReleaseDetail,
+  QualityReleasePreview,
+} from "@/lib/wp7-schemas";
+
+const ERROR_MESSAGE: Record<string, string> = {
+  golden_set_empty: "所选 JD 没有黄金标签，无法度量",
+  active_rule_missing: "有 JD 缺少 active 规则版本",
+  invalid_active_rule: "有 JD 的 active 规则不合法",
+  release_input_changed: "输入已变化，请重新预览",
+  invalid_release_window: "观察窗口不合法",
+  release_window_too_large: "观察窗口不能超过 365 天",
+  release_transaction_conflict: "并发冲突，请重试",
+};
+
+function describe(error: unknown): string {
+  if (error instanceof ApiError) {
+    return ERROR_MESSAGE[error.code] ?? error.message;
+  }
+  return (error as Error).message;
+}
+
+export function ReleaseCreate({ canCreate }: { canCreate: boolean }) {
+  const [open, setOpen] = React.useState(false);
+  const [preview, setPreview] = React.useState<QualityReleasePreview | null>(null);
+  const queryClient = useQueryClient();
+
+  const previewMutation = useMutation({
+    mutationFn: () =>
+      apiPost("/api/v1/quality/releases/preview", {}, QualityReleasePreview),
+    onSuccess: setPreview,
+    onError: (error) => toast.error(describe(error)),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: () => {
+      if (!preview) throw new Error("先预览再创建");
+      // Echo the previewed window and fingerprint so the server can refuse if
+      // the inputs moved underneath us.
+      return apiPost(
+        "/api/v1/quality/releases",
+        {
+          window_start: preview.window_start,
+          window_end: preview.window_end,
+          expected_input_fingerprint: preview.input_fingerprint,
+        },
+        QualityReleaseDetail,
+      );
+    },
+    onSuccess: (detail) => {
+      toast.success(`已创建发布 #${detail.id}`);
+      setOpen(false);
+      setPreview(null);
+      void queryClient.invalidateQueries({ queryKey: ["quality-releases"] });
+    },
+    onError: (error) => toast.error(describe(error)),
+  });
+
+  if (!canCreate) return null;
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setPreview(null);
+      }}
+    >
+      <SheetTrigger
+        render={<Button onClick={() => previewMutation.mutate()}>创建发布</Button>}
+      />
+      <SheetContent side="right" aria-label="创建质量发布">
+        <SheetTitle>创建质量发布</SheetTitle>
+        <SheetDescription>
+          先预览本次将要冻结的输入，确认后创建。创建后不可修改。
+        </SheetDescription>
+
+        {previewMutation.isPending && <p className="text-sm">正在预览…</p>}
+
+        {preview && (
+          <div className="space-y-4 text-sm">
+            <dl className="space-y-1">
+              <dt className="text-muted-foreground">观察窗口</dt>
+              <dd className="font-mono text-xs">
+                {preview.window_start} → {preview.window_end}
+              </dd>
+            </dl>
+            <dl className="space-y-1">
+              <dt className="text-muted-foreground">黄金集</dt>
+              <dd>
+                共 {preview.golden_total} 条（推进 {preview.golden_advance}／淘汰{" "}
+                {preview.golden_reject}／borderline {preview.golden_borderline}）
+              </dd>
+            </dl>
+            <dl className="space-y-1">
+              <dt className="text-muted-foreground">评分覆盖</dt>
+              <dd>
+                已覆盖 {preview.score_covered}，未覆盖 {preview.score_uncovered}
+              </dd>
+            </dl>
+            <dl className="space-y-1">
+              <dt className="text-muted-foreground">绑定的规则版本</dt>
+              <dd>
+                {preview.selected
+                  .map((s) => `${s.jd_code}@${s.rule_version_id}`)
+                  .join("、")}
+              </dd>
+            </dl>
+            <dl className="space-y-1">
+              <dt className="text-muted-foreground">输入指纹</dt>
+              <dd className="font-mono text-xs break-all">
+                {preview.input_fingerprint}
+              </dd>
+            </dl>
+
+            <Button
+              onClick={() => createMutation.mutate()}
+              disabled={createMutation.isPending}
+            >
+              {createMutation.isPending ? "创建中…" : "确认创建"}
+            </Button>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
Closes three functional gaps left by PR #8, found by auditing the delivered work against the WP7 plan rather than against my own summary of it.

## 1. Cross-checks were never triggered by review outcomes

Task 11 required the feedback and golden-set services to queue a cross-check inside the caller's transaction. Only the scoring pipeline did. That left the two highest-signal triggers dead:

- a reviewer disagreeing with the AI (`ai_hr_disagreement`)
- a newly imported golden label contradicting an existing score (`golden_error`)

Both services now queue through a shared `services/cross_check/triggers.py`, no longer commit internally, and hand the queued ids back so the router commits business + queue writes together and only then sends the Celery message. A rolled-back feedback can no longer leave an orphaned check.

## 2. Quality releases could not be created from the UI

The backend had preview and create; the page was a list. `/reports/quality` is now a server component that resolves the role, and `hr_lead`/`admin` get a preview sheet showing exactly what is about to be frozen — window, golden composition, score coverage, bound rule versions, and the input fingerprint — which the create call echoes back so the server can refuse a stale preview.

## 3. Cross-check backfill had no entry point

`/reports/cross-checks` now offers the admin-only backfill with a dry run first, and reports selected / already-existing / queued counts.

## Gate

- backend offline 541 passed; full integration 210 passed (2 new trigger tests)
- Ruff clean; mypy clean across 114 application source files
- frontend lint/typecheck clean; Vitest 71
- Playwright e2e 22 across desktop and mobile (new `wp7-quality.spec.ts` covers the role gate and the preview → create flow)
- `next build` succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)